### PR TITLE
Added compe_latex_insert_code option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,5 +26,16 @@ require('compe').setup {
 }
 ```
 
+## Options
+
+### Insert the code
+
+You can customize to insert either the symbol or the code itself with `b:compe_latex_insert_code`.
+
+```vim
+" Always insert the code in markdown files
+autocmd FileType markdown let b:compe_latex_insert_code = v:true
+```
+
 [nvim-compe]: https://github.com/hrsh7th/nvim-compe/
 [packer.nvim]: https://github.com/wbthomason/packer.nvim/

--- a/lua/compe_latex_symbols/init.lua
+++ b/lua/compe_latex_symbols/init.lua
@@ -2,6 +2,14 @@ local compe = require 'compe'
 
 local Source = {}
 
+local function copytable(orig)
+	local copy = {}
+	for orig_key, orig_value in pairs(orig) do
+		copy[orig_key] = orig_value
+	end
+	return copy
+end
+
 function Source.get_metadata(self)
 	return {
 		priority = 100,
@@ -69,7 +77,13 @@ function Source.complete(self, args)
 	local items = {}
 	for code, symbol in pairs(symbols_1l[first_letter]) do
 		if code:sub(1, #input):lower() == input:lower() then
-			table.insert(items, symbol)
+			if vim.g.compe_latex_insert_code then
+				local symbol_rev = copytable(symbol)
+				symbol_rev.word = symbol_rev.menu
+				table.insert(items, symbol_rev)
+			else
+				table.insert(items, symbol)
+			end
 		end
 	end
 

--- a/lua/compe_latex_symbols/init.lua
+++ b/lua/compe_latex_symbols/init.lua
@@ -2,14 +2,6 @@ local compe = require 'compe'
 
 local Source = {}
 
-local function copytable(orig)
-	local copy = {}
-	for orig_key, orig_value in pairs(orig) do
-		copy[orig_key] = orig_value
-	end
-	return copy
-end
-
 function Source.get_metadata(self)
 	return {
 		priority = 100,
@@ -78,7 +70,7 @@ function Source.complete(self, args)
 	for code, symbol in pairs(symbols_1l[first_letter]) do
 		if code:sub(1, #input):lower() == input:lower() then
 			if vim.b.compe_latex_insert_code then
-				local symbol_rev = copytable(symbol)
+				local symbol_rev = vim.deepcopy(symbol)
 				symbol_rev.word = symbol_rev.menu
 				table.insert(items, symbol_rev)
 			else

--- a/lua/compe_latex_symbols/init.lua
+++ b/lua/compe_latex_symbols/init.lua
@@ -77,7 +77,7 @@ function Source.complete(self, args)
 	local items = {}
 	for code, symbol in pairs(symbols_1l[first_letter]) do
 		if code:sub(1, #input):lower() == input:lower() then
-			if vim.g.compe_latex_insert_code then
+			if vim.b.compe_latex_insert_code then
 				local symbol_rev = copytable(symbol)
 				symbol_rev.word = symbol_rev.menu
 				table.insert(items, symbol_rev)


### PR DESCRIPTION
Now the script will check for `compe_latex_insert_code` option and if it's true, a new copy of table will be returned in which the value of `word` key will be replaced with the value of `menu` key and thus the code will be inserted rather than the symbol.

let g:compe_latex_insert_code = v:false
![let g:compe_latex_insert_code = v:false](https://user-images.githubusercontent.com/66555275/118241184-95cc2480-b4bb-11eb-93ad-e806c2d6fa73.png)

let g:compe_latex_insert_code = v:true
![let g:compe_latex_insert_code = v:true](https://user-images.githubusercontent.com/66555275/118241388-cc09a400-b4bb-11eb-8f38-9131f24af8ce.png)